### PR TITLE
Added single API method of "editBug"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "0.11"
+  - "0.12"
   - "0.10"
+  - "iojs"
 

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ var PROTOCOL = 'https';
  *     setCurrentFilter: string, search: string}}
  */
 var URLs = {
+  edit: '%s://%s/api.asp?cmd=edit&token=%s&ixBug=%s&cols=%s',
   logon: '%s://%s/api.asp?cmd=logon&email=%s&password=%s',
   logoff: '%s://%s/api.asp?cmd=logoff&token=%s',
   listFilters: '%s://%s/api.asp?cmd=listFilters&token=%s',
@@ -74,6 +75,7 @@ var URLs = {
 var MODULE_ERRORS = {
   undefined_token: 'token is undefined; you are not logged in',
   xml_parse_error: 'invalid xml received from server',
+  bug_not_found: 'could not find bug',
   unknown: 'unknown error'
 };
 
@@ -189,7 +191,7 @@ var fogbugz = {
   logon: function logon() {
     var dfrd = Q.defer(),
       extractToken = function extractToken(xml) {
-        var r = _parse(xml);
+        var r = _parse(xml, dfrd);
         if (r) {
           return r.response.token[0];
         }
@@ -243,7 +245,7 @@ var fogbugz = {
     var token = cache.get('token'),
       dfrd = Q.defer(),
       extractFilters = function extractFilters(xml) {
-        var r = _parse(xml);
+        var r = _parse(xml, dfrd);
         if (r) {
           return r.response.filters[0].filter
             .map(function (filter) {
@@ -324,10 +326,10 @@ var fogbugz = {
       cases, fields,
       dfrd = Q.defer(),
       extractCases = function extractCases(xml) {
-        var r = _parse(xml);
+        var r = _parse(xml, dfrd);
         if (!r || !r.response || !r.response.cases.length ||
           !r.response.cases[0].case) {
-          return dfrd.reject('could not find bug');
+          return dfrd.reject(MODULE_ERRORS.bug_not_found);
         }
         cases = r.response.cases[0].case.map(function (kase) {
           var bug = new Case({
@@ -393,6 +395,92 @@ var fogbugz = {
     }
     return dfrd.promise;
 
+  },
+
+  /**
+   * Edit a bug by ID
+   * @method editBug
+   * @param {number} [id] -- the ixBug of a case that you want edit
+   * @param {Object} [parameters] -- the parameters you want edit
+   * @param {array} [cols] The columns you want returned about this case
+   * @returns {Function|promise|Q.promise} Promise
+   */
+  editBug: function editBug(id, parameters, cols) {
+    var token = cache.get('token'),
+      cases, fields,
+      dfrd = Q.defer(),
+      extractCases = function extractCases(xml) {
+        var r = _parse(xml, dfrd);
+        if (!r || !r.response || !r.response.case ||
+          !r.response.case.length ) {
+          return dfrd.reject(MODULE_ERRORS.xml_parse_error);
+        } else {
+          cases = r.response.case.map(function(kase) {
+            var bug = new Case({
+              id: kase.$.ixBug,
+              operations: kase.$.operations.split(','),
+              title: kase.sTitle[0].trim(),
+              status: kase.sStatus[0].trim(),
+              url: format('%s://%s/default.asp?%s', PROTOCOL, conf.host,
+                kase.$.ixBug),
+              fixFor: kase.sFixFor[0].trim()
+            });
+            if (kase.sPersonAssignedTo) {
+              bug.assignedTo = kase.sPersonAssignedTo[0].trim();
+              bug.assignedToEmail = kase.sEmailAssignedTo[0].trim();
+            }
+            if (kase.tags && kase.tags[0].tag) {
+              bug.tags = kase.tags[0].tag.join(', ');
+            }
+            // find anything leftover in the case, disregarding the fields we
+            // already
+            _(kase)
+              .keys()
+              .difference(_.keys(bug).concat('sTitle', 'sStatus', '$',
+                'sFixFor', 'sPersonAssignedTo',
+                'sEmailAssignedTo'))
+              .each(function(key) {
+                var value = kase[key];
+                bug[key] = _.isArray(value) && value.length === 1 ?
+                  bug[key] = value[0].trim() : // dereference
+                value;
+              });
+            bug._raw = kase;
+            return bug;
+          });
+          if (cases.length > 1) {
+            return cases;
+          }
+          return cases[0];
+        }
+      };
+    fields = cols.concat(DEFAULT_COLS).join(',');
+    id = encodeURIComponent(id);
+
+    if (!token) {
+      dfrd.reject(MODULE_ERRORS.undefined_token);
+    } else {
+      var url = format(URLs.edit, PROTOCOL, conf.host, token, id, fields);
+      // Some work need to do, parameters .....
+      Object.keys(parameters).forEach(function(k) {
+        url += '&' + k + '=' + parameters[k];
+      });
+      request(url, function(err, res, body) {
+        var cases;
+        if (err) {
+          dfrd.reject(err);
+        } else {
+          cases = extractCases(body);
+          if (!cases) {
+            console.error(body);
+            dfrd.reject(MODULE_ERRORS.unknown);
+          } else {
+            dfrd.resolve(cases);
+          }
+        }
+      });
+    }
+    return dfrd.promise;
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "grunt": "^0.4.1",
     "grunt-bump": "0.0.14",
-    "grunt-cli": "^0.1.9",
+    "grunt-cli": "^0.1.13",
     "grunt-eslint": "^13.0.0",
     "grunt-jasmine-node": "^0.2.1"
   },

--- a/spec/fogbugz.spec.js
+++ b/spec/fogbugz.spec.js
@@ -5,6 +5,49 @@ var moduleLoader = require('./module-loader');
 var loadModule = moduleLoader.loadModule;
 
 describe('fogbugz module', function () {
+  
+  describe('editBug method', function() {
+    var emptyXml = '<response></response>';
+    var editBugXml = '<response><case ixBug="16006" operations="edit,assign,resolve,email,remind"><sTitle><![CDATA[AQ toolkit API: bar chart shown and selected for text]]></sTitle><sFixFor><![CDATA[whenever]]></sFixFor><sStatus><![CDATA[ Active ]]></sStatus><sFooBar><![CDATA[FOO FOO FOO]]></sFooBar></case></response>';
+    var editBugRequest = function(xml) {
+        return jasmine.createSpy('request').andCallFake(function (url, cb) {
+            cb(null, null, xml || editBugXml);
+          });        
+      };
+      
+    it ('should fail if id is not found. ', function(done) {      
+        var request = editBugRequest(emptyXml);
+        var fogbugz = loadModule('./index.js', { request: request }).module.exports;            
+        
+        fogbugz.setToken('capybara');
+        fogbugz.editBug(16227, {}, [])
+          .then(function() {
+            expect(true).toBe(false);
+          }, function (err) {
+            expect(err).toBe(fogbugz.MODULE_ERRORS.xml_parse_error);
+          })
+          .finally(fogbugz.forgetToken)
+          .finally(done);
+    });
+    
+    it('should find the requested bug. ', function(done) {      
+        var request = editBugRequest();
+        var fogbugz = loadModule('./index.js', { request: request }).module.exports;            
+        var testId = '16006';
+        
+        fogbugz.setToken('capybara');
+        fogbugz.editBug(testId, {}, [])
+          .then(function(fbzCase) {
+            expect(fbzCase.id).toEqual(testId);
+            expect(fbzCase.title).toEqual('AQ toolkit API: bar chart shown and selected for text');            
+          }, function (err) {
+            console.log(err);
+            expect(true).toBe(false);
+          })
+          .finally(fogbugz.forgetToken)
+          .finally(done);
+    });
+  });
 
   describe('logon method', function () {
 
@@ -58,8 +101,8 @@ describe('fogbugz module', function () {
     });
   });
 
-  describe('logoff method', function (done) {
-    it('should fail w/o presence of token', function () {
+  describe('logoff method', function () {
+    it('should fail w/o presence of token', function (done) {
       var mocks = {},
         fogbugz;
       fogbugz = loadModule('./index.js', mocks).module.exports;


### PR DESCRIPTION
Added editBug from wangyangjun/node-fogbugz patch-2 branch

https://github.com/wangyangjun/node-fogbugz/commit/3797cb7993c81825d166517b1766b56dc641ed33

Updated bug in spec (no functional change)

Added MODULE_ERROR for bug not fund

Added bug_not_found and updated use in search.
Changed the editBug to return xml parse error, since that is really what it is returning, it's not checking for a case (would be nice).

Added Tests for editBug method

Pretty minimal, but we're testing that we'll get an error if there is not result.
And testing that we'll get the case that we expected to be working on.

Updated Parse to pass in the defferred.

Otherwise it depends on the context which may change.