### PR TITLE
pwd compatibility for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,11 @@
  * @version 0.2.0
  * @license MIT
  */
+var pwd = process.env.PWD || process.cwd();
 var request = require('request'),
   Q = require('q'),
   path = require('path'),
-  conf = require(path.join(process.env.PWD || process.cwd(), 'fogbugz.conf.json')),
+  conf = require(path.join(pwd, 'fogbugz.conf.json')),
   format = require('util').format,
   extend = require('util')._extend,
   xml2js = require('xml2js'),

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@
 var request = require('request'),
   Q = require('q'),
   path = require('path'),
-  conf = require(path.join(process.env.PWD, 'fogbugz.conf.json')),
+  conf = require(path.join(process.env.PWD || process.cwd(), 'fogbugz.conf.json')),
   format = require('util').format,
   extend = require('util')._extend,
   xml2js = require('xml2js'),


### PR DESCRIPTION
Previous pull request caused line to be 4 characters longer than the linting rules permitted, broke out the fix into its own variable.

Uses process.cwd() as the pwd when process.env.PWD doesn't exist.

