### PR TITLE
Updating codeclimate-test-reporter to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "chai": "^3.2.0",
     "chai-as-promised": "^6.0.0",
     "codacy-coverage": "^1.1.2",
-    "codeclimate-test-reporter": "^0.4.0",
+    "codeclimate-test-reporter": "^0.4.1",
     "grunt": "^0.4.5",
     "grunt-bump": "^0.3.1",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION

Please update [codeclimate-test-reporter](https://npmjs.org/package/codeclimate-test-reporter) to version 0.4.1.

If this passes your tests you can merge it in.  If not please use this branch for changes.



View the [change log](https://github.com/codeclimate/javascript-test-reporter/compare/cb80deb6667f62b701dcfea47b9143ceea6c7c1d...cb80deb6667f62b701dcfea47b9143ceea6c7c1d).